### PR TITLE
*os.Root usage and support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ fslock provides a cross-process mutex based on file locks that works on windows 
 (don't ask)
 </sub></sup>
 
-fslock relies on LockFileEx on Windows and flock on \*nix systems.  The timeout 
-feature uses overlapped IO on Windows, but on \*nix platforms, timing out
-requires the use of a goroutine that will run until the lock is acquired,
-regardless of timeout.  If you need to avoid this use of goroutines, poll
-TryLock in a loop. 
+fslock relies on LockFileEx on Windows and flock on \*nix systems.  The timed and
+context-bounded calls (LockWithTimeout and LockWithContext) use overlapped IO on
+Windows.  On \*nix systems a blocking flock cannot be interrupted once it parks,
+so these calls instead poll with a non-blocking flock until the lock is acquired
+or the deadline or cancellation fires.
 
 
 
@@ -40,9 +40,17 @@ Lock implements cross-process locks using syscalls.
 
 ### func New
 ``` go
-func New(filename string) *Lock
+func New(filename string) (*Lock, error)
 ```
-New returns a new lock around the given file.
+New returns a new lock around the given file. It opens a handle to the file's
+parent directory and returns an error if that directory cannot be opened.
+
+### func (\*Lock) Close
+``` go
+func (l *Lock) Close() error
+```
+Close releases the directory handle held by the lock. It does not release a
+held lock; call Unlock first. The lock must not be used after Close.
 
 
 ### func (\*Lock) Lock
@@ -50,6 +58,14 @@ New returns a new lock around the given file.
 func (l *Lock) Lock() error
 ```
 Lock locks the lock.  This call will block until the lock is available.
+
+### func (\*Lock) LockWithContext
+``` go
+func (l *Lock) LockWithContext(ctx context.Context) error
+```
+LockWithContext tries to lock the lock until the context is canceled or its
+deadline is exceeded.  If the context is canceled before the lock is acquired,
+this method returns ctx.Err().
 
 ### func (\*Lock) LockWithTimeout
 ``` go

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ or the deadline or cancellation fires.
 
 ## Variables
 ``` go
+var ErrInvalidName error = errors.New("fslock: lock name must be a single path component")
+```
+ErrInvalidName indicates that the name passed to NewInRoot was not a single path
+component within the root: it was empty, ".", "..", or contained a path
+separator.
+
+``` go
 var ErrLocked error = trylockError("fslock is already locked")
 ```
 ErrLocked indicates TryLock failed because the lock was already locked.
@@ -44,6 +51,22 @@ func New(filename string) (*Lock, error)
 ```
 New returns a new lock around the given file. It opens a handle to the file's
 parent directory and returns an error if that directory cannot be opened.
+
+### func NewInRoot
+``` go
+func NewInRoot(root *os.Root, name string) (*Lock, error)
+```
+NewInRoot returns a new lock around the file named name within root. name must
+be a single path component: it may not be empty, ".", "..", or contain a path
+separator, and otherwise NewInRoot returns ErrInvalidName. To lock a file in a
+subdirectory, pass a sub-root obtained from root.OpenRoot. The lock file is
+resolved relative to a directory handle, so it can never escape root via
+symlinks or "..".
+
+The lock borrows root only for the duration of this call: it opens its own
+independent handle to root's directory, which it owns and which Close releases.
+The caller retains ownership of root and may close it independently of the
+returned Lock.
 
 ### func (\*Lock) Close
 ``` go

--- a/fslock.go
+++ b/fslock.go
@@ -6,6 +6,27 @@
 // It is built on top of flock for linux and darwin, and LockFileEx on Windows.
 package fslock
 
+import (
+	"errors"
+	"strings"
+)
+
+// ErrInvalidName indicates that the name passed to NewInRoot was not a single
+// path component within the root: it was empty, ".", "..", or contained a path
+// separator.
+var ErrInvalidName error = errors.New("fslock: lock name must be a single path component")
+
+// validLockName reports whether name is a single, non-special path component
+// suitable for resolving against a root directory. It rejects "", ".", "..",
+// and any name containing a '/' or '\' separator on every platform (so that a
+// name is interpreted identically regardless of the host's separator).
+func validLockName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return !strings.ContainsAny(name, `/\`)
+}
+
 // ErrTimeout indicates that the lock attempt timed out.
 var ErrTimeout error = timeoutError("lock timeout exceeded")
 

--- a/fslock_nix.go
+++ b/fslock_nix.go
@@ -7,6 +7,9 @@ package fslock
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 )
@@ -14,13 +17,58 @@ import (
 // Lock implements cross-process locks using syscalls.
 // This implementation is based on flock syscall.
 type Lock struct {
-	filename string
-	fd       int
+	// root is a capability-scoped handle to the directory containing the
+	// lock file. All access to the lock file goes through it, so operations
+	// can never escape this directory via symlinks or "..".
+	root *os.Root
+	// name is the base name of the lock file within root.
+	name string
+	// file is the open lock file while the lock is held; nil otherwise.
+	file *os.File
 }
 
-// New returns a new lock around the given file.
-func New(filename string) *Lock {
-	return &Lock{filename: filename}
+// New returns a new lock around the given file. It opens a handle to the
+// file's parent directory and returns an error if that directory cannot be
+// opened.
+func New(filename string) (*Lock, error) {
+	root, err := os.OpenRoot(filepath.Dir(filename))
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{root: root, name: filepath.Base(filename)}, nil
+}
+
+// Close releases the directory handle held by the lock. It does not release a
+// held lock; call Unlock first. The lock must not be used after Close.
+func (l *Lock) Close() error {
+	return l.root.Close()
+}
+
+// maxOpenRetries bounds how many times open retries the os.Root O_CREATE race
+// described below. The race clears within a handful of attempts in practice;
+// the cap exists only so that a genuinely missing lock directory (which also
+// reports ENOENT) eventually surfaces an error instead of spinning forever.
+const maxOpenRetries = 100
+
+func (l *Lock) open() error {
+	// Root.OpenFile forces O_NOFOLLOW on the final component (and O_CLOEXEC),
+	// so we only request the create/access flags here. On platforms without
+	// openat2 -- everything but Linux -- that O_NOFOLLOW create is not atomic
+	// against concurrent creators: on macOS (observed through go1.26.2) it
+	// intermittently returns a spurious ENOENT instead of opening the file.
+	// The lock file is never removed while a lock is in use, so retry a bounded
+	// number of times; a persistent ENOENT (e.g. the lock directory itself was
+	// removed) is still returned to the caller.
+	for try := 0; ; try++ {
+		f, err := l.root.OpenFile(l.name, os.O_CREATE|os.O_RDWR, 0600)
+		if err == nil {
+			l.file = f
+			return nil
+		}
+		if try >= maxOpenRetries || !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
 }
 
 // Lock locks the lock.  This call will block until the lock is available.
@@ -28,7 +76,7 @@ func (l *Lock) Lock() error {
 	if err := l.open(); err != nil {
 		return err
 	}
-	return syscall.Flock(l.fd, syscall.LOCK_EX)
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX)
 }
 
 // TryLock attempts to lock the lock.  This method will return ErrLocked
@@ -37,9 +85,10 @@ func (l *Lock) TryLock() error {
 	if err := l.open(); err != nil {
 		return err
 	}
-	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	if err != nil {
-		syscall.Close(l.fd)
+		l.file.Close()
+		l.file = nil
 	}
 	if err == syscall.EWOULDBLOCK {
 		return ErrLocked
@@ -47,23 +96,14 @@ func (l *Lock) TryLock() error {
 	return err
 }
 
-func (l *Lock) open() error {
-	fd, err := syscall.Open(l.filename, syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC, 0600)
-	if err != nil {
-		return err
-	}
-	l.fd = fd
-	return nil
-}
-
 // Unlock unlocks the lock.
 func (l *Lock) Unlock() error {
-	if l.fd < 0 {
+	if l.file == nil {
 		return nil
 	}
-	_ = syscall.Flock(l.fd, syscall.LOCK_UN)
-	err := syscall.Close(l.fd)
-	l.fd = -1
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	err := l.file.Close()
+	l.file = nil
 	return err
 }
 
@@ -74,7 +114,7 @@ const maxLockPoll = 32 * time.Millisecond
 // tryFlock makes a single non-blocking attempt to acquire the lock. It returns
 // (true, nil) if the lock was acquired, (false, nil) if it is currently held by
 // someone else (so the caller should wait and retry), and (false, err) on a
-// real error, in which case it has already closed and cleared the fd.
+// real error, in which case it has already closed and cleared the file.
 //
 // flock cannot be canceled or given a deadline once it blocks, and closing the
 // fd does not unblock an in-flight blocking flock. So rather than parking a
@@ -82,7 +122,7 @@ const maxLockPoll = 32 * time.Millisecond
 // possibly forever), the timed/contextual waiters poll with LOCK_NB.
 func (l *Lock) tryFlock() (bool, error) {
 	for {
-		switch err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB); err {
+		switch err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err {
 		case nil:
 			return true, nil
 		case syscall.EINTR:
@@ -91,8 +131,8 @@ func (l *Lock) tryFlock() (bool, error) {
 		case syscall.EWOULDBLOCK:
 			return false, nil
 		default:
-			syscall.Close(l.fd)
-			l.fd = -1
+			l.file.Close()
+			l.file = nil
 			return false, err
 		}
 	}
@@ -113,8 +153,8 @@ func (l *Lock) LockWithTimeout(timeout time.Duration) error {
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			syscall.Close(l.fd)
-			l.fd = -1
+			l.file.Close()
+			l.file = nil
 			return ErrTimeout
 		}
 		time.Sleep(min(backoff, remaining))
@@ -138,8 +178,8 @@ func (l *Lock) LockWithContext(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			t.Stop()
-			syscall.Close(l.fd)
-			l.fd = -1
+			l.file.Close()
+			l.file = nil
 			return ctx.Err()
 		case <-t.C:
 		}

--- a/fslock_nix.go
+++ b/fslock_nix.go
@@ -35,7 +35,34 @@ func New(filename string) (*Lock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Lock{root: root, name: filepath.Base(filename)}, nil
+	// NewInRoot opens its own handle to the directory, so the temporary root
+	// we opened here can be released as soon as it returns.
+	defer root.Close()
+	return NewInRoot(root, filepath.Base(filename))
+}
+
+// NewInRoot returns a new lock around the file named name within root. name
+// must be a single path component: it may not be empty, ".", "..", or contain a
+// path separator, and otherwise NewInRoot returns ErrInvalidName. To lock a file
+// in a subdirectory, pass a sub-root obtained from root.OpenRoot. All access to
+// the lock file goes through a directory handle, so it can never escape root via
+// symlinks or "..".
+//
+// The lock borrows root only for the duration of this call: it opens its own
+// independent handle to root's directory, which it owns and which Close
+// releases. The caller retains ownership of root and may close it independently
+// of the returned Lock.
+func NewInRoot(root *os.Root, name string) (*Lock, error) {
+	if !validLockName(name) {
+		return nil, ErrInvalidName
+	}
+	// Open our own independent root over the same directory so the Lock's
+	// lifetime is decoupled from the caller's: Close releases only this handle.
+	own, err := root.OpenRoot(".")
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{root: own, name: name}, nil
 }
 
 // Close releases the directory handle held by the lock. It does not release a

--- a/fslock_test.go
+++ b/fslock_test.go
@@ -56,6 +56,75 @@ func TestLockNoContention(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNewInRoot(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	defer root.Close()
+
+	lock, err := fslock.NewInRoot(root, "testing")
+	require.NoError(t, err)
+	defer lock.Close()
+
+	require.NoError(t, lock.Lock())
+	require.NoError(t, lock.Unlock())
+}
+
+// TestNewInRootDecoupledFromCallerRoot verifies that the lock opens its own
+// handle and keeps working after the caller closes the root they supplied.
+func TestNewInRootDecoupledFromCallerRoot(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+
+	lock, err := fslock.NewInRoot(root, "testing")
+	require.NoError(t, err)
+	defer lock.Close()
+
+	// The lock must not depend on the caller's root staying open.
+	require.NoError(t, root.Close())
+
+	require.NoError(t, lock.Lock())
+	require.NoError(t, lock.Unlock())
+}
+
+// TestNewInRootSubRoot exercises the intended way to lock a file in a
+// subdirectory: hand NewInRoot a sub-root rather than a multi-component name.
+func TestNewInRootSubRoot(t *testing.T) {
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, root.Mkdir("sub", 0700))
+	sub, err := root.OpenRoot("sub")
+	require.NoError(t, err)
+	defer sub.Close()
+
+	lock, err := fslock.NewInRoot(sub, "testing")
+	require.NoError(t, err)
+	defer lock.Close()
+
+	require.NoError(t, lock.Lock())
+	require.NoError(t, lock.Unlock())
+
+	// The lock file should have been created within the subdirectory.
+	_, err = os.Stat(filepath.Join(dir, "sub", "testing"))
+	require.NoError(t, err)
+}
+
+func TestNewInRootInvalidName(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	defer root.Close()
+
+	for _, name := range []string{"", ".", "..", "a/b", "a\\b", "/abs", "sub/lock"} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			lock, err := fslock.NewInRoot(root, name)
+			require.ErrorIs(t, err, fslock.ErrInvalidName)
+			require.Nil(t, lock)
+		})
+	}
+}
+
 func TestLockBlocks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
 	lock, err := fslock.New(path)

--- a/fslock_test.go
+++ b/fslock_test.go
@@ -26,7 +26,8 @@ const shortWait = 10 * time.Millisecond
 
 func TestLockNoContention(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
-	lock := fslock.New(path)
+	lock, err := fslock.New(path)
+	require.NoError(t, err)
 
 	started := make(chan struct{})
 	acquired := make(chan struct{})
@@ -51,13 +52,14 @@ func TestLockNoContention(t *testing.T) {
 		t.Fatalf("Timed out waiting for lock acquisition.")
 	}
 
-	err := lock.Unlock()
+	err = lock.Unlock()
 	require.NoError(t, err)
 }
 
 func TestLockBlocks(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
-	lock := fslock.New(path)
+	lock, err := fslock.New(path)
+	require.NoError(t, err)
 
 	kill := make(chan struct{})
 
@@ -97,16 +99,18 @@ func TestLockBlocks(t *testing.T) {
 }
 
 func TestTryLock(t *testing.T) {
-	lock := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	lock, err := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	require.NoError(t, err)
 
-	err := lock.TryLock()
+	err = lock.TryLock()
 	require.NoError(t, err)
 	lock.Unlock()
 }
 
 func TestTryLockNoBlock(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
-	lock := fslock.New(path)
+	lock, err := fslock.New(path)
+	require.NoError(t, err)
 
 	kill := make(chan struct{})
 
@@ -144,16 +148,18 @@ func TestTryLockNoBlock(t *testing.T) {
 }
 
 func TestUnlockedWithTimeout(t *testing.T) {
-	lock := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	lock, err := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	require.NoError(t, err)
 
-	err := lock.LockWithTimeout(shortWait)
+	err = lock.LockWithTimeout(shortWait)
 	require.NoError(t, err)
 	lock.Unlock()
 }
 
 func TestLockWithTimeout(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
-	lock := fslock.New(path)
+	lock, err := fslock.New(path)
+	require.NoError(t, err)
 	defer lock.Unlock()
 
 	kill := make(chan struct{})
@@ -192,18 +198,20 @@ func TestLockWithTimeout(t *testing.T) {
 }
 
 func TestUnlockedWithContext(t *testing.T) {
-	lock := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	lock, err := fslock.New(filepath.Join(t.TempDir(), "testing"))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), shortWait)
 	defer cancel()
-	err := lock.LockWithContext(ctx)
+	err = lock.LockWithContext(ctx)
 	require.NoError(t, err)
 	lock.Unlock()
 }
 
 func TestLockWithContextDeadlineExceeded(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "testing")
-	lock := fslock.New(path)
+	lock, err := fslock.New(path)
+	require.NoError(t, err)
 
 	kill := make(chan struct{})
 
@@ -218,7 +226,7 @@ func TestLockWithContextDeadlineExceeded(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), shortWait)
 	defer cancel()
-	err := lock.LockWithContext(ctx)
+	err = lock.LockWithContext(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -237,9 +245,10 @@ func TestStress(t *testing.T) {
 
 	var stress = func() {
 		defer wg.Done()
-		lock := fslock.New(filepath.Join(dir, "testing"))
+		lock, err := fslock.New(filepath.Join(dir, "testing"))
+		assert.NoError(t, err)
 		for range lockAttempts {
-			err := lock.Lock()
+			err = lock.Lock()
 			assert.NoError(t, err)
 			state := atomic.AddInt32(lockState, 1)
 			assert.Equal(t, int32(1), state)
@@ -369,8 +378,9 @@ func TestLockFromOtherProcess(t *testing.T) {
 		return
 	}
 	filename := os.Getenv("FSLOCK_TEST_HELPER_PATH")
-	lock := fslock.New(filename)
-	err := lock.Lock()
+	lock, err := fslock.New(filename)
+	require.NoError(t, err)
+	err = lock.Lock()
 	require.NoError(t, err)
 
 	// Signal the parent that the lock is now held.

--- a/fslock_windows.go
+++ b/fslock_windows.go
@@ -5,27 +5,51 @@ package fslock
 
 import (
 	"context"
-	"log"
+	"os"
+	"path/filepath"
 	"runtime"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-func init() {
-	log.SetFlags(log.Lmicroseconds | log.Ldate)
-}
-
 // Lock implements cross-process locks using syscalls.
 // This implementation is based on LockFileEx syscall.
 type Lock struct {
-	filename string
-	handle   windows.Handle
+	// dir is a handle to the directory containing the lock file. It is used
+	// as the RootDirectory for NtCreateFile, so the lock file is resolved
+	// relative to it rather than by an absolute path and cannot escape it.
+	dir *os.File
+	// name is the base name of the lock file within dir.
+	name string
+	// handle is the open lock file while the lock is held; InvalidHandle
+	// otherwise.
+	handle windows.Handle
 }
 
-// New returns a new lock around the given file.
-func New(filename string) *Lock {
-	return &Lock{filename: filename, handle: windows.InvalidHandle}
+// New returns a new lock around the given file. It opens a handle to the
+// file's parent directory and returns an error if that directory cannot be
+// opened.
+func New(filename string) (*Lock, error) {
+	root, err := os.OpenRoot(filepath.Dir(filename))
+	if err != nil {
+		return nil, err
+	}
+	// Take an independent handle to the directory itself; it remains valid
+	// after the root is closed and serves as the RootDirectory below.
+	dir, err := root.Open(".")
+	root.Close()
+	if err != nil {
+		return nil, err
+	}
+	return &Lock{dir: dir, name: filepath.Base(filename), handle: windows.InvalidHandle}, nil
+}
+
+// Close releases the directory handle held by the lock. It does not release a
+// held lock; call Unlock first. The lock must not be used after Close.
+func (l *Lock) Close() error {
+	return l.dir.Close()
 }
 
 // TryLock attempts to lock the lock.  This method will return ErrLocked
@@ -54,25 +78,49 @@ func (l *Lock) Unlock() error {
 	return windows.Close(h)
 }
 
+// open creates (if necessary) and opens the lock file relative to the
+// directory handle. It opens for asynchronous I/O so that LockFileEx below can
+// wait with a timeout, and shared so that other processes can open the file
+// (but will still need to lock it).
+func (l *Lock) open() (windows.Handle, error) {
+	name, err := windows.NewNTUnicodeString(l.name)
+	if err != nil {
+		return 0, err
+	}
+	oa := &windows.OBJECT_ATTRIBUTES{
+		RootDirectory: windows.Handle(l.dir.Fd()),
+		ObjectName:    name,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	oa.Length = uint32(unsafe.Sizeof(*oa))
+
+	var iosb windows.IO_STATUS_BLOCK
+	var handle windows.Handle
+	err = windows.NtCreateFile(
+		&handle,
+		windows.GENERIC_READ,
+		oa,
+		&iosb,
+		nil, // AllocationSize
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ,
+		windows.FILE_OPEN_IF, // create if absent, open if present (OPEN_ALWAYS)
+		// FILE_NON_DIRECTORY_FILE without any FILE_SYNCHRONOUS_IO_* option
+		// leaves the handle open for overlapped (asynchronous) I/O.
+		windows.FILE_NON_DIRECTORY_FILE,
+		0, // EaBuffer
+		0, // EaLength
+	)
+	if err != nil {
+		return 0, err
+	}
+	return handle, nil
+}
+
 // LockWithTimeout tries to lock the lock until the timeout expires.  If the
 // timeout expires, this method will return ErrTimeout.
 func (l *Lock) LockWithTimeout(timeout time.Duration) (oerr error) {
-	name, err := windows.UTF16PtrFromString(l.filename)
-	if err != nil {
-		return err
-	}
-
-	// Open for asynchronous I/O so that we can timeout waiting for the lock.
-	// Also open shared so that other processes can open the file (but will
-	// still need to lock it).
-	handle, err := windows.CreateFile(
-		name,
-		windows.GENERIC_READ,
-		windows.FILE_SHARE_READ,
-		nil,
-		windows.OPEN_ALWAYS,
-		windows.FILE_FLAG_OVERLAPPED|windows.FILE_ATTRIBUTE_NORMAL,
-		0)
+	handle, err := l.open()
 	if err != nil {
 		return err
 	}
@@ -137,22 +185,7 @@ func (l *Lock) LockWithTimeout(timeout time.Duration) (oerr error) {
 // LockWithContext tries to lock the lock until the context is canceled or its deadline is exceeded.
 // If the context is canceled before the lock is acquired, this method returns ctx.Err().
 func (l *Lock) LockWithContext(ctx context.Context) (oerr error) {
-	name, err := windows.UTF16PtrFromString(l.filename)
-	if err != nil {
-		return err
-	}
-
-	// Open for asynchronous I/O so that the lock can be issued without blocking
-	// and we can wait on it alongside context cancellation. Also open shared so
-	// that other processes can open the file (but will still need to lock it).
-	handle, err := windows.CreateFile(
-		name,
-		windows.GENERIC_READ,
-		windows.FILE_SHARE_READ,
-		nil,
-		windows.OPEN_ALWAYS,
-		windows.FILE_FLAG_OVERLAPPED|windows.FILE_ATTRIBUTE_NORMAL,
-		0)
+	handle, err := l.open()
 	if err != nil {
 		return err
 	}

--- a/fslock_windows.go
+++ b/fslock_windows.go
@@ -36,14 +36,35 @@ func New(filename string) (*Lock, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Take an independent handle to the directory itself; it remains valid
-	// after the root is closed and serves as the RootDirectory below.
+	// NewInRoot opens its own handle to the directory, so the temporary root
+	// we opened here can be released as soon as it returns.
+	defer root.Close()
+	return NewInRoot(root, filepath.Base(filename))
+}
+
+// NewInRoot returns a new lock around the file named name within root. name
+// must be a single path component: it may not be empty, ".", "..", or contain a
+// path separator, and otherwise NewInRoot returns ErrInvalidName. To lock a file
+// in a subdirectory, pass a sub-root obtained from root.OpenRoot. The lock file
+// is resolved relative to a directory handle, so it can never escape root via
+// symlinks or "..".
+//
+// The lock borrows root only for the duration of this call: it opens its own
+// independent handle to root's directory, which it owns and which Close
+// releases. The caller retains ownership of root and may close it independently
+// of the returned Lock.
+func NewInRoot(root *os.Root, name string) (*Lock, error) {
+	if !validLockName(name) {
+		return nil, ErrInvalidName
+	}
+	// Take an independent handle to the directory itself, owned by the Lock; it
+	// remains valid after the caller closes their root and serves as the
+	// RootDirectory in open below.
 	dir, err := root.Open(".")
-	root.Close()
 	if err != nil {
 		return nil, err
 	}
-	return &Lock{dir: dir, name: filepath.Base(filename), handle: windows.InvalidHandle}, nil
+	return &Lock{dir: dir, name: name, handle: windows.InvalidHandle}, nil
 }
 
 // Close releases the directory handle held by the lock. It does not release a

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/dolthub/fslock
 
-go 1.22
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.30.0
+	golang.org/x/sys v0.41.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
All *Lock instances now carry a `*os.Root` instance and must be `Close()`d independency of `Lock()`/`Unlock()` calls. `fslock.New()` is now fallible.

`NewInRoot` allows a caller to supply their own `Root` instance. In that case, path separators in the `path` are prohibited.

The Windows implementation migrates to `NtCreateFile` to get the `*os.Root` subpath handling we are looking for.